### PR TITLE
Count amount of incorrect bonks user has done

### DIFF
--- a/pkg/cli/bonk.go
+++ b/pkg/cli/bonk.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-
+	"net"
+	
 	"github.com/KingJorjai/BONK/pkg/api"
 )
 
@@ -43,6 +44,25 @@ const (
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀`
 )
 
+// getMacAddr attempts to get the MAC address of the user, and return it as a string
+//
+// Side effects: None 
+func getMacAddr() ([]string, error) {
+    ifas, err := net.Interfaces()
+    if err != nil {
+        return nil, err
+    }
+    var as []string
+    for _, ifa := range ifas {
+        a := ifa.HardwareAddr.String()
+        if a != "" {
+            as = append(as, a)
+        }
+    }
+    return as, nil
+}
+
+
 // Bonk performs a "bonk" operation on the specified entity.
 //
 // It validates that the provided name contains only letters, numbers, and spaces
@@ -65,6 +85,13 @@ func Bonk(name string) {
 	if !match {
 		fmt.Println(ASCII_NO_BONK)
 		fmt.Println("BONK DENIED! That name is too sus. Use only letters and numbers (1-100 characters). No bonking the void!")
+		userMac, er:= getMacAddr()
+		if er == nil {
+			failNumber, er := api.CountUp(userMac[0])
+			if er == nil {
+				fmt.Printf("Are you proud, bonker? %d incorrect bonks already!\n", failNumber);
+			}
+		}
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Just as a hall-of-fame is planned for the most bonked users, it is a good idea to design a hall-of-shame too: Who has skipped the rules the most, trying to do incorrect bonks?

The code in this PR gets the MAC address of the user each time a bonk is attempted with an incorrect name string. It calls the API, increasing the count of said address by one, and the user is notified of their count of fails.

**Problem**: Currently, this feature uses the same bonking API as the actual bonks. Therefore, if someone were to bonk MAC addresses (why would they?), these would go towards the incorrect bonking count of an innocent user.